### PR TITLE
Add transform to remove payload from replay-events

### DIFF
--- a/src/main/java/com/clickhouse/kafka/connect/transforms/FVDropReplayData.java
+++ b/src/main/java/com/clickhouse/kafka/connect/transforms/FVDropReplayData.java
@@ -1,0 +1,86 @@
+package com.clickhouse.kafka.connect.transforms;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.transforms.Transformation;
+import org.apache.kafka.connect.transforms.util.SimpleConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static org.apache.kafka.connect.transforms.util.Requirements.requireStruct;
+
+@SuppressWarnings("unused")
+public class FVDropReplayData<R extends ConnectRecord<R>> implements Transformation<R> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FVDropReplayData.class);
+    @SuppressWarnings("unused")
+    public static final String OVERVIEW_DOC = "Remove the binary payloads from events that are replay-events";
+
+    private static final String PURPOSE = "transform payload";
+
+    private interface ConfigName {
+        String TOPIC_FIELD = "topicName";
+    }
+
+    private String topicName;
+
+    public static final ConfigDef CONFIG_DEF = new ConfigDef()
+            .define(FVDropReplayData.ConfigName.TOPIC_FIELD, ConfigDef.Type.STRING, ConfigDef.NO_DEFAULT_VALUE, null, ConfigDef.Importance.HIGH,
+                    "Source topic name");
+
+    @Override
+    public R apply(R record) {
+
+        try {
+
+            final Struct value = requireStruct(record.value(), PURPOSE);
+            final Schema valueSchema = record.valueSchema();
+            final Struct updatedValue = new Struct(valueSchema);
+
+            // copy all the fields
+            boolean needsRemoval = false;
+            for (Field field : value.schema().fields()) {
+                Object fieldValue = value.get(field);
+
+                if (fieldValue != null && Objects.equals(field.name(), "is_replay_event") && fieldValue instanceof Boolean) {
+                    needsRemoval = true;
+                }
+                updatedValue.put(field.name(), fieldValue);
+
+            }
+
+            // if this record contains replay-data, we make it empty
+            if (needsRemoval) {
+                updatedValue.put("payload", "");
+            }
+            return record.newRecord(topicName, record.kafkaPartition(), record.keySchema(), record.key(), valueSchema, updatedValue, record.timestamp());
+        } catch (Exception e) {
+            LOGGER.error("Error handling binary payload", e);
+            throw e;
+        }
+    }
+
+    @Override
+    public ConfigDef config() {
+        return CONFIG_DEF;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public void configure(Map<String, ?> props) {
+        final SimpleConfig config = new SimpleConfig(CONFIG_DEF, props);
+        this.topicName = config.getString(ConfigName.TOPIC_FIELD);
+
+        LOGGER.info("Configuring FVDropReplayData, topicName: {}", topicName);
+    }
+}


### PR DESCRIPTION
FullView Transform:
Allows to remove the binary payload from replay-events while keeping the others so we don't necessarily ingest huge blobs of payloads into CH while still having them available for S3 storage on the same topic.
